### PR TITLE
fix incorrect login notification

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -123,7 +123,6 @@ services:
 
   worker-ray:
     build: ./morpheus-worker/ray
-    image: morpheus-worker:latest
     command: ray start --head --dashboard-host 0.0.0.0 --block
     ports:
       - "8000:8000"
@@ -135,7 +134,7 @@ services:
         condition: service_started
 
   worker-ray-deployer:
-    image: morpheus-worker:latest
+    build: ./morpheus-worker/ray
     command: bash -c "sleep 5 && ray job submit -- serve deploy models.yaml"
     environment:
       - RAY_ADDRESS=http://worker-ray:8265

--- a/morpheus-client/context/AuthContext.tsx
+++ b/morpheus-client/context/AuthContext.tsx
@@ -24,6 +24,8 @@ export enum AuthOption {
   Reset = "reset",
 }
 
+const USER = "user"
+
 export interface IAuthContext {
   authLoading: boolean;
   authOption: AuthOption;
@@ -59,7 +61,7 @@ const AuthProvider = (props: { children: ReactNode }) => {
   const [authLoading, setAuthLoading] = useState<boolean>(true);
   const [authOption, setAuthOption] = useState<AuthOption>(AuthOption.Login);
   const [user, setUser] = useState<any>({});
-  const [localUser, setLocalUser] = useLocalStorage("user", {} as User);
+  const [localUser, setLocalUser] = useLocalStorage(USER, {} as User);
 
   useEffect(() => {
     if (localUser && localUser.email) {
@@ -90,8 +92,8 @@ const AuthProvider = (props: { children: ReactNode }) => {
       .then((response) => {
         loadOrCreateMorpheusUser({ ...response, displayName: user.name });
       })
-      .catch(() => {
-        showErrorAlert("An error occurred while creating the new user");
+      .catch((error) => {
+        showErrorAlert(error.message);
       });
   };
 
@@ -102,7 +104,7 @@ const AuthProvider = (props: { children: ReactNode }) => {
           loadOrCreateMorpheusUser(response);
         })
         .catch((error) => {
-          showErrorAlert( "An error occurred while authenticating the user");
+          showErrorAlert(error.message);
           reject(error);
         });
     });
@@ -116,7 +118,7 @@ const AuthProvider = (props: { children: ReactNode }) => {
           resolve();
         })
         .catch((error) => {
-          showErrorAlert( "An error occurred while authenticating the user");
+          showErrorAlert(error.message);
           reject(error);
         });
     });
@@ -135,7 +137,7 @@ const AuthProvider = (props: { children: ReactNode }) => {
   };
 
   const loadOrCreateUser = (user: any) => {
-    const newData = { ...user, role: "user" };
+    const newData = { ...user, role: USER };
     loadOrCreateUserInfo(newData)
       .then((response: any) => {
         if (response.success) {
@@ -173,8 +175,8 @@ const AuthProvider = (props: { children: ReactNode }) => {
         setUser({} as User);
         setLocalUser({} as User);
       })
-      .catch(() => {
-        showErrorAlert("An error occurred while logging out");
+      .catch((error) => {
+        showErrorAlert(error.message);
       });
   };
 

--- a/morpheus-client/services/auth.ts
+++ b/morpheus-client/services/auth.ts
@@ -10,44 +10,38 @@ import {
 
 import { auth } from "../lib/firebaseClient";
 
-export const signUpWithEmailAndPasswordFirebase = async (
-  user: any
-): Promise<any> => {
+export const signUpWithEmailAndPasswordFirebase = async (user: any): Promise<any> => {
   return new Promise((resolve, reject) => {
     createUserWithEmailAndPassword(auth, user.email, user.password)
       .then((userCredential) => {
         resolve(userCredential.user);
       })
       .catch((error) => {
-        reject(mapAuthCodeToMessage(error.code));
+        reject(new Error(mapAuthCodeToMessage[error.code] || "Something went wrong with your sign up process"));
       });
   });
 };
 
-export const loginWithEmailAndPasswordFirebase = async (
-  user: any
-): Promise<any> => {
+export const loginWithEmailAndPasswordFirebase = async (user: any): Promise<any> => {
   return new Promise((resolve, reject) => {
     signInWithEmailAndPassword(auth, user.email, user.password)
       .then((userCredential) => {
         resolve(userCredential.user);
       })
       .catch((error) => {
-        reject(mapAuthCodeToMessage(error.code));
+        reject(new Error(mapAuthCodeToMessage[error.code] || "Something went wrong with your authentication process"));
       });
   });
 };
 
-export const sendUserPasswordResetEmail = async (
-  email: string
-): Promise<any> => {
+export const sendUserPasswordResetEmail = async (email: string): Promise<any> => {
   return new Promise((resolve, reject) => {
     sendPasswordResetEmail(auth, email)
       .then(() => {
         resolve(true);
       })
       .catch((error) => {
-        reject(mapAuthCodeToMessage(error.code));
+        reject(new Error(mapAuthCodeToMessage[error.code] || "Something went wrong with your password reset process"));
       });
   });
 };
@@ -62,7 +56,7 @@ export const loginWithGoogleFirebase = async (): Promise<any> => {
         resolve({ user, additionalInfo });
       })
       .catch((error) => {
-        reject(mapAuthCodeToMessage(error.code));
+        reject(new Error(mapAuthCodeToMessage[error.code] || "Something went wrong with your authentication process"));
       });
   });
 };
@@ -74,44 +68,20 @@ export const signOutFirebase = async (): Promise<any> => {
         resolve(true);
       })
       .catch((error) => {
-        reject(mapAuthCodeToMessage(error.code));
+        reject(new Error(mapAuthCodeToMessage[error.code] || "Something went wrong with your sign out process"));
       });
   });
 };
 
-const mapAuthCodeToMessage = (authCode: string) => {
-  switch (authCode) {
-    case "auth/wrong-password":
-      return "Password provided is not correct";
-
-    case "auth/invalid-password":
-      return "Password provided is not correct";
-
-    case "auth/invalid-email":
-      return "Email provided is invalid";
-
-    case "auth/invalid-display-name":
-      return "Display name provided is invalid";
-
-    case "auth/invalid-phone-number":
-      return "Phone number provided is invalid";
-
-    case "auth/invalid-photo-url":
-      return "Photo URL provided is invalid";
-
-    case "auth/invalid-uid":
-      return "UID provided is invalid";
-
-    case "auth/invalid-provider-id":
-      return "Provider ID provided is invalid";
-
-    case "auth/email-already-in-use":
-      return "Email provided is already in use";
-
-    case "auth/user-not-found":
-      return "User not found";
-
-    default:
-      return "Something went wrong with your authentication process";
-  }
+const mapAuthCodeToMessage: { [key: string]: string } = {
+  "auth/wrong-password": "Password provided is not correct",
+  "auth/invalid-password": "Password provided is not correct",
+  "auth/invalid-email": "Email provided is invalid",
+  "auth/invalid-display-name": "Display name provided is invalid",
+  "auth/invalid-phone-number": "Phone number provided is invalid",
+  "auth/invalid-photo-url": "Photo URL provided is invalid",
+  "auth/invalid-uid": "UID provided is invalid",
+  "auth/invalid-provider-id": "Provider ID provided is invalid",
+  "auth/email-already-in-use": "Email provided is already in use",
+  "auth/user-not-found": "User not found",
 };


### PR DESCRIPTION
# Update login notifications
* Issue: resolves #60
*  Target: Fix login notifications with messages that make more sense to the user.
### Observations
1. The switch-case structure for error codes was changed by object literal.
```js
const mapAuthCodeToMessage: { [key: string]: string } = {
  "auth/wrong-password": "Password provided is not correct",
  "auth/invalid-password": "Password provided is not correct",
  "auth/invalid-email": "Email provided is invalid",
  "auth/invalid-display-name": "Display name provided is invalid",
  "auth/invalid-phone-number": "Phone number provided is invalid",
  "auth/invalid-photo-url": "Photo URL provided is invalid",
  "auth/invalid-uid": "UID provided is invalid",
  "auth/invalid-provider-id": "Provider ID provided is invalid",
  "auth/email-already-in-use": "Email provided is already in use",
  "auth/user-not-found": "User not found",
};
``` 
3. The errors were propagated to the parent functions by reject. This looks like this for most cases: 
```js
   reject(new Error(mapAuthCodeToMessage[error.code] || "Something went wrong with your sign up process"));
```
 