### PR TITLE
feat(back): admin/add script model functions as register integration

### DIFF
--- a/morpheus-data/morpheus_data/config.py
+++ b/morpheus-data/morpheus_data/config.py
@@ -32,6 +32,7 @@ class Settings(BaseSettings):
     aws_access_key_id: str = ""
     aws_secret_access_key: str = ""
 
+    temp_model_folder: str = "./tmp"
     model_default: str = "stabilityai/stable-diffusion-2"
     sampler_default: str = "PNDMScheduler"
     max_num_images: int = 4

--- a/morpheus-data/morpheus_data/database/init_data/controlnet_models.py
+++ b/morpheus-data/morpheus_data/database/init_data/controlnet_models.py
@@ -1,6 +1,5 @@
 from morpheus_data.database.init_data.categories import controlnet, processing
 
-
 controlnet_models = [
     {
         "name": "Canny edges",
@@ -9,6 +8,7 @@ controlnet_models = [
             "conditions. This checkpoint corresponds to the ControlNet conditioned on Canny edges."
         ),
         "source": "lllyasviel/sd-controlnet-canny",
+        "kind": "controlnet",
         "url_docs": "https://huggingface.co/lllyasviel/sd-controlnet-canny",
         "categories": [controlnet, processing],
         "extra_params": {"type": "canny"},
@@ -20,6 +20,7 @@ controlnet_models = [
             "conditions. This checkpoint corresponds to the ControlNet conditioned on Depth estimation."
         ),
         "source": "lllyasviel/sd-controlnet-depth",
+        "kind": "controlnet",
         "url_docs": "https://huggingface.co/lllyasviel/sd-controlnet-depth",
         "categories": [controlnet, processing],
         "extra_params": {"type": "depth"},
@@ -31,6 +32,7 @@ controlnet_models = [
             "conditions. This checkpoint corresponds to the ControlNet conditioned on Image Segmentation."
         ),
         "source": "lllyasviel/sd-controlnet-seg",
+        "kind": "controlnet",
         "url_docs": "https://huggingface.co/lllyasviel/sd-controlnet-seg",
         "categories": [controlnet, processing],
         "extra_params": {"type": "seg"},
@@ -42,6 +44,7 @@ controlnet_models = [
             "conditions. This checkpoint corresponds to the ControlNet conditioned on HED Boundary."
         ),
         "source": "lllyasviel/sd-controlnet-hed",
+        "kind": "controlnet",
         "url_docs": "https://huggingface.co/lllyasviel/sd-controlnet-hed",
         "categories": [controlnet, processing],
         "extra_params": {"type": "hed"},
@@ -54,6 +57,7 @@ controlnet_models = [
             " detection."
         ),
         "source": "lllyasviel/sd-controlnet-mlsd",
+        "kind": "controlnet",
         "url_docs": "https://huggingface.co/lllyasviel/sd-controlnet-mlsd",
         "categories": [controlnet, processing],
         "extra_params": {"type": "mlsd"},
@@ -66,6 +70,7 @@ controlnet_models = [
             "Estimation."
         ),
         "source": "lllyasviel/sd-controlnet-normal",
+        "kind": "controlnet",
         "url_docs": "https://huggingface.co/lllyasviel/sd-controlnet-normal",
         "categories": [controlnet, processing],
         "extra_params": {"type": "normalmap"},
@@ -78,6 +83,7 @@ controlnet_models = [
             "Estimation."
         ),
         "source": "lllyasviel/sd-controlnet-openpose",
+        "kind": "controlnet",
         "url_docs": "https://huggingface.co/lllyasviel/sd-controlnet-openpose",
         "categories": [controlnet, processing],
         "extra_params": {"type": "poses"},
@@ -89,6 +95,7 @@ controlnet_models = [
             "conditions. This checkpoint corresponds to the ControlNet conditioned on Scribble images."
         ),
         "source": "lllyasviel/sd-controlnet-scribble",
+        "kind": "controlnet",
         "url_docs": "https://huggingface.co/lllyasviel/sd-controlnet-scribble",
         "categories": [controlnet, processing],
         "extra_params": {"type": "scribble"},

--- a/morpheus-data/morpheus_data/database/init_data/sd_models.py
+++ b/morpheus-data/morpheus_data/database/init_data/sd_models.py
@@ -5,6 +5,7 @@ sd_models = [
         "name": "Stable Diffusion XL",
         "description": "SDXL 1.0: A Leap Forward in AI Image Generation",
         "source": "stabilityai/stable-diffusion-xl-base-1.0",
+        "kind": "diffusion",
         "url_docs": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
         "categories": [text2img],
     },
@@ -13,6 +14,7 @@ sd_models = [
         "description": "This is a model that can be used to generate and modify images based on text prompts. It is a "
         "Latent Diffusion Model that uses a fixed, pretrained text encoder (OpenCLIP-ViT/H).",
         "source": "stabilityai/stable-diffusion-2",
+        "kind": "diffusion",
         "url_docs": "https://huggingface.co/stabilityai/stable-diffusion-2",
         "categories": [text2img, img2img],
     },
@@ -21,6 +23,7 @@ sd_models = [
         "description": "Openjourney is an open source Stable Diffusion fine tuned model on Midjourney images, "
         "by PromptHero.",
         "source": "prompthero/openjourney",
+        "kind": "diffusion",
         "url_docs": "https://huggingface.co/prompthero/openjourney",
         "categories": [text2img, img2img],
     },
@@ -32,6 +35,7 @@ sd_models = [
         "fine-tuned on 595k steps at resolution 512x512 on 'laion-aesthetics v2 5+' and 10% dropping "
         "of the text-conditioning to improve classifier-free guidance sampling.",
         "source": "runwayml/stable-diffusion-v1-5",
+        "kind": "diffusion",
         "url_docs": "https://huggingface.co/runwayml/stable-diffusion-v1-5",
         "categories": [text2img, img2img, controlnet],
     },
@@ -39,6 +43,7 @@ sd_models = [
         "name": "Instruct Pix2Pix",
         "description": "Modify an existing image with a text prompt.",
         "source": "timbrooks/instruct-pix2pix",
+        "kind": "diffusion",
         "url_docs": "https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/pix2pix",
         "categories": [pix2pix],
     },
@@ -46,6 +51,7 @@ sd_models = [
         "name": "SD Inpainting",
         "description": "Modify an existing image with a text prompt and an image mask.",
         "source": "runwayml/stable-diffusion-inpainting",
+        "kind": "diffusion",
         "url_docs": "https://huggingface.co/runwayml/stable-diffusion-inpainting",
         "categories": [inpainting],
     },
@@ -55,6 +61,7 @@ sd_models = [
             "Stable Diffusion x4 Upscaler can be used to enhance the resolution of input images by a " "factor of 4."
         ),
         "source": "stabilityai/stable-diffusion-x4-upscaler",
+        "kind": "diffusion",
         "url_docs": "https://huggingface.co/stabilityai/stable-diffusion-x4-upscaler",
         "categories": [upscaling],
     },

--- a/morpheus-data/morpheus_data/migrations/versions/2c4d7d46d3a1_initial_migration.py
+++ b/morpheus-data/morpheus_data/migrations/versions/2c4d7d46d3a1_initial_migration.py
@@ -1,8 +1,8 @@
 """Initial migration
 
-Revision ID: 24e4bc0bd38d
+Revision ID: 2c4d7d46d3a1
 Revises: 
-Create Date: 2023-08-14 18:45:23.691605
+Create Date: 2023-09-18 17:04:18.128975
 
 """
 from alembic import op
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
-revision = '24e4bc0bd38d'
+revision = '2c4d7d46d3a1'
 down_revision = None
 branch_labels = None
 depends_on = None
@@ -22,6 +22,7 @@ def upgrade() -> None:
     sa.Column('id', postgresql.UUID(as_uuid=True), nullable=False),
     sa.Column('name', sa.String(length=64), nullable=True),
     sa.Column('source', sa.String(length=512), nullable=True),
+    sa.Column('kind', sa.String(length=64), nullable=True),
     sa.Column('description', sa.String(length=512), nullable=True),
     sa.Column('url_docs', sa.String(length=512), nullable=True),
     sa.Column('extra_params', sa.JSON(), nullable=True),

--- a/morpheus-data/morpheus_data/models/models.py
+++ b/morpheus-data/morpheus_data/models/models.py
@@ -93,6 +93,7 @@ class MLModel(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = Column(String(64), nullable=True)
     source = Column(String(512), nullable=True)
+    kind = Column(String(64), nullable=True)
     description = Column(String(512), nullable=True)
     url_docs = Column(String(512), nullable=True)
     categories = relationship(

--- a/morpheus-data/morpheus_data/models/schemas.py
+++ b/morpheus-data/morpheus_data/models/schemas.py
@@ -70,6 +70,12 @@ class ControlNetType(str, Enum):
     poses = "poses"
 
 
+class ModelKind(str, Enum):
+    diffusion = "diffusion"
+    controlnet = "controlnet"
+    prompt = "prompt"
+
+
 class Prompt(BaseModel):
     prompt: str = Field(..., min_length=1)
     model: str
@@ -221,6 +227,7 @@ class ModelCategory(BaseModel):
 class MLModelCreate(BaseModel):
     name: str
     source: str
+    kind: ModelKind = None
     description: str = None
     url_docs: str = None
     categories: List[ModelCategory] = None
@@ -232,6 +239,7 @@ class MLModelCreate(BaseModel):
             "example": {
                 "name": "Model Name",
                 "source": "https://modelurl.com",
+                "kind": "diffusion",
                 "description": "Model description",
                 "url_docs": "https://modeldocs.com",
                 "is_active": True,
@@ -249,6 +257,7 @@ class MLModel(MLModelCreate):
                 "id": "c0a80121-7ac0-11eb-9439-0242ac130002",
                 "name": "Model Name",
                 "source": "https://modelurl.com",
+                "kind": "diffusion",
                 "description": "Model description",
                 "url_docs": "https://modeldocs.com",
                 "is_active": True,

--- a/morpheus-data/morpheus_data/registry/interfaces.py
+++ b/morpheus-data/morpheus_data/registry/interfaces.py
@@ -1,0 +1,32 @@
+from abc import ABC, abstractmethod
+
+
+class ModelRegistryInterface(ABC):
+
+    @abstractmethod
+    def register_model_in_storage(self, *, output_path: str) -> None:
+        raise NotImplementedError("This method is not implemented")
+
+    @abstractmethod
+    def delete_model_from_storage(self, *,  name):
+        raise NotImplementedError("This method is not implemented")
+
+    @abstractmethod
+    def list_storage(self, *,  folder: str = "") -> None:
+        raise NotImplementedError("This method is not implemented")
+
+
+class ModelManagerInterface(ABC):
+    @abstractmethod
+    def download_model(self, *, kind: str, model: str) -> str:
+        raise NotImplementedError("This method is not implemented")
+
+    @abstractmethod
+    def remove_model(self, *, model: str) -> None:
+        raise NotImplementedError("This method is not implemented")
+
+    @abstractmethod
+    def list_models(self) -> list:
+        raise NotImplementedError("This method is not implemented")
+
+

--- a/morpheus-data/morpheus_data/registry/model_manager.py
+++ b/morpheus-data/morpheus_data/registry/model_manager.py
@@ -1,0 +1,123 @@
+import shutil
+from glob import glob
+from pathlib import Path
+
+import torch
+from diffusers import ControlNetModel, StableDiffusionPipeline
+from dynamicprompts.generators import RandomPromptGenerator
+from dynamicprompts.generators.magicprompt import MagicPromptGenerator
+
+from morpheus_data.config import get_settings
+from morpheus_data.models.schemas import MLModelCreate
+from morpheus_data.registry.interfaces import ModelManagerInterface
+from morpheus_data.utils.decorators import validate_stable_diffusion_upscaler
+
+settings = get_settings()
+TEMP_MODEL_FOLDER = settings.temp_model_folder
+
+
+@validate_stable_diffusion_upscaler
+def download_model_from_huggingface(params: MLModelCreate):
+    output = params.source.replace(" ", "_")
+    path = f"{TEMP_MODEL_FOLDER}/{output}"
+
+    if Path(path).exists():
+        print(f"Model was already downloaded. You can find it in {path}")
+        return output
+    try:
+        model = StableDiffusionPipeline.from_pretrained(
+            params.source,
+            revision="fp16",
+            torch_dtype=torch.float16,
+        )
+    except OSError as e:
+        print("OSerror", e)
+        model = StableDiffusionPipeline.from_pretrained(
+            params.source,
+            # revision="fp16",
+            torch_dtype=torch.float16,
+        )
+    model.save_pretrained(f"{TEMP_MODEL_FOLDER}/{output}")
+    return output
+
+
+def download_controlnet_model_from_huggingface(params: MLModelCreate):
+    output = params.source.replace(" ", "_")
+    path = f"{TEMP_MODEL_FOLDER}/{output}"
+    model = ""
+
+    if Path(path).exists():
+        print(f"ControlNet Model was already downloaded. You can find it in {path}")
+        return output
+    try:
+        model = ControlNetModel.from_pretrained(
+            params.source,
+            torch_dtype=torch.float16,
+        )
+    except OSError as e:
+        print("OSerror", e)
+        model = ControlNetModel.from_pretrained(
+            params.source,
+            torch_dtype=torch.float16,
+        )
+    model.save_pretrained(f"{TEMP_MODEL_FOLDER}/{output}")
+    return output
+
+
+def download_magicprompt_model_from_huggingface(params):
+    output = params.source.replace(" ", "_")
+    path = f"{TEMP_MODEL_FOLDER}/{output}"
+
+    if Path(path).exists():
+        print(f"MagicPrompt Model was already downloaded. You can find it in {path}")
+        return output
+    try:
+        generator = RandomPromptGenerator()
+        magic_generator = MagicPromptGenerator(prompt_generator=generator, model_name=params.source, device="cpu")
+    except OSError as e:
+        print("OSerror", e)
+
+    magic_generator.generator.save_pretrained(f"{TEMP_MODEL_FOLDER}/{output}")
+    return output
+
+
+def remove_model_from_disk(name):
+    path = f"{TEMP_MODEL_FOLDER}/{name}"
+    if not Path(path).exists():
+        print("Folder not found in local")
+        return
+    shutil.rmtree(f"{TEMP_MODEL_FOLDER}/{name}")
+    print(f"Model deleted from {TEMP_MODEL_FOLDER} folder")
+
+
+def list_models_in_disk() -> list:
+    path = f"{TEMP_MODEL_FOLDER}/"
+    if not Path(path).exists():
+        print("Folder not found in local")
+        return
+    return glob(f"{TEMP_MODEL_FOLDER}/*/*")
+
+
+# Map kind of model to their corresponding functions to download models
+download_model = {
+    "diffusion": download_model_from_huggingface,
+    "controlnet": download_controlnet_model_from_huggingface,
+    "prompt": download_magicprompt_model_from_huggingface,
+}
+
+
+class ModelManagerHuggingFace(ModelManagerInterface):
+    def __init__(self, *, model_manager_factory=None):
+        if model_manager_factory is None:
+            model_manager_factory = download_model
+        self.model_manager = model_manager_factory
+
+    def download_model(self, *, kind: str, params: MLModelCreate) -> str:
+        output_path = self.model_manager[kind](params)
+        return output_path
+
+    def remove_model(self, *, name: str) -> None:
+        remove_model_from_disk(name)
+
+    def list_models(self) -> list:
+        return list_models_in_disk()

--- a/morpheus-data/morpheus_data/registry/s3_model_registry.py
+++ b/morpheus-data/morpheus_data/registry/s3_model_registry.py
@@ -1,0 +1,33 @@
+from glob import glob
+from pathlib import Path
+
+from morpheus_data.config import get_settings
+from morpheus_data.registry.interfaces import ModelRegistryInterface
+from morpheus_data.repository.files.s3_models_repository import S3ModelFileRepository  # noqa: E402
+
+settings = get_settings()
+TEMP_MODEL_FOLDER = settings.temp_model_folder
+
+
+class S3ModelRegistry(ModelRegistryInterface):
+    def __init__(self):
+        self.model_repository = S3ModelFileRepository()
+
+    def register_model_in_storage(self, *, output_path: str) -> None:
+        is_in_s3 = self.model_repository.files_exists(output_path)
+
+        if is_in_s3:
+            print("Model already exists in s3")
+            return
+
+        list_of_content = glob(f"{TEMP_MODEL_FOLDER}/{output_path}/**/*", recursive=True)
+        list_of_files = [file for file in list_of_content if Path(file).is_file()]
+        self.model_repository.upload_files(list_of_files)
+        print("Model uploaded to the S3 bucket")
+
+    def delete_model_from_storage(self, *, name):
+        self.model_repository.delete_file(name.replace(" ", "_"))
+        print("Model deleted from S3 bucket")
+
+    def list_storage(self, *, folder: str = "") -> None:
+        self.model_repository.list_content(folder=folder)

--- a/morpheus-data/morpheus_data/utils/decorators.py
+++ b/morpheus-data/morpheus_data/utils/decorators.py
@@ -1,0 +1,35 @@
+import json
+from functools import wraps
+from morpheus_data.config import get_settings
+
+settings = get_settings()
+
+TEMP_MODEL_FOLDER = settings.temp_model_folder
+
+
+def validate_stable_diffusion_upscaler(func):
+    @wraps(func)
+    def wrapper_check_stable_diffusion_upscaler(*args, **kwargs):
+        output = func(*args, **kwargs)
+        if output == "stabilityai/stable-diffusion-x4-upscaler":
+            print("Fixing Stable Diffusion Upscaling 4x model")
+            fix_stable_diffusion_upscaling_4x_model(f"{TEMP_MODEL_FOLDER}/{output}/model_index.json")
+            print("Fixed!")
+        return output
+
+    return wrapper_check_stable_diffusion_upscaler
+
+
+def fix_stable_diffusion_upscaling_4x_model(file_path):
+    # Load JSON file
+    with open(file_path, "r") as json_file:
+        data = json.load(json_file)
+
+    # Remove the problematic entries
+    data.pop("watermarker", None)
+    data.pop("feature_extractor", None)
+    data.pop("safety_checker", None)
+
+    # Overwrite the JSON file
+    with open(file_path, "w") as json_file:
+        json.dump(data, json_file, indent=2)

--- a/morpheus-data/pyproject.toml
+++ b/morpheus-data/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
     "tqdm>=4.65.0",
     "pillow>=9.5.0",
     "fastapi>=0.95.1",
+    "torch==1.13.1",
+    "diffusers==0.20.0",
+    "dynamicprompts[attentiongrabber,magicprompt]"
 ]
 
 [build-system]

--- a/morpheus-server/scripts/models/cli.py
+++ b/morpheus-server/scripts/models/cli.py
@@ -1,6 +1,3 @@
-import shutil
-from pathlib import Path
-
 import typer
 from omegaconf import OmegaConf
 from rich import print
@@ -11,6 +8,8 @@ import s3
 from config import APIServer, DBTarget, Target, api_server_urls, config_file, download_model, models_url
 from utils import load_config_from_file
 
+from morpheus_data.registry.model_manager import remove_model_from_disk, list_models_in_disk
+
 cli = typer.Typer(rich_markup_mode="rich")
 
 cli.add_typer(s3.app, name="s3")
@@ -20,12 +19,11 @@ console = Console()
 
 
 def remove_model_from_local(name):
-    path = f"./tmp/{name}"
-    if not Path(path).exists():
-        print("Folder not found in local")
-        return
-    shutil.rmtree(f"./tmp/{name}")
-    print("Model deleted from tmp folder")
+    try:
+        remove_model_from_disk(name)
+        print(f"Model {name} deleted from local")
+    except Exception as e:
+        raise Exception(f"Error deleting model from local: {e}")
 
 
 @cli.command("upload")
@@ -98,6 +96,11 @@ def delete_model(
         db.delete_model_from_db_by_source(
             server_url=f"{api_server_urls[api_server]}/{models_url[target]}", model_source=name
         )
+
+
+@cli.command("list")
+def list_model():
+    print(list_models_in_disk())
 
 
 @cli.command("test")

--- a/morpheus-server/scripts/models/config.py
+++ b/morpheus-server/scripts/models/config.py
@@ -3,7 +3,7 @@ from functools import lru_cache
 
 from pydantic import BaseSettings
 
-from utils import (
+from morpheus_data.registry.model_manager import (
     download_controlnet_model_from_huggingface,
     download_magicprompt_model_from_huggingface,
     download_model_from_huggingface,

--- a/morpheus-server/scripts/models/controlnet-models-info.yaml
+++ b/morpheus-server/scripts/models/controlnet-models-info.yaml
@@ -3,6 +3,7 @@ models:
     type: "canny"
     description: "ControlNet is a neural network structure to control diffusion models by adding extra conditions. This checkpoint corresponds to the ControlNet conditioned on Canny edges."
     source: "lllyasviel/sd-controlnet-canny"
+    kind: "controlnet"
     is_active: true
     url_docs: "https://huggingface.co/lllyasviel/sd-controlnet-canny"
 
@@ -10,6 +11,7 @@ models:
     type: "depth"
     description: "ControlNet is a neural network structure to control diffusion models by adding extra conditions. This checkpoint corresponds to the ControlNet conditioned on Depth estimation."
     source: "lllyasviel/sd-controlnet-depth"
+    kind: "controlnet"
     is_active: true
     url_docs: "https://huggingface.co/lllyasviel/sd-controlnet-depth"
 
@@ -17,6 +19,7 @@ models:
     type: "seg"
     description: "ControlNet is a neural network structure to control diffusion models by adding extra conditions. This checkpoint corresponds to the ControlNet conditioned on Image Segmentation."
     source: "lllyasviel/sd-controlnet-seg"
+    kind: "controlnet"
     is_active: true
     url_docs: "https://huggingface.co/lllyasviel/sd-controlnet-seg"
 
@@ -24,6 +27,7 @@ models:
     type: "hed"
     description: "ControlNet is a neural network structure to control diffusion models by adding extra conditions. This checkpoint corresponds to the ControlNet conditioned on HED Boundary."
     source: "lllyasviel/sd-controlnet-hed"
+    kind: "controlnet"
     is_active: true
     url_docs: "https://huggingface.co/lllyasviel/sd-controlnet-hed"
   
@@ -31,6 +35,7 @@ models:
     type: "mlsd"
     description: "ControlNet is a neural network structure to control diffusion models by adding extra conditions. This checkpoint corresponds to the ControlNet conditioned on M-LSD straight line detection."
     source: "lllyasviel/sd-controlnet-mlsd"
+    kind: "controlnet"
     is_active: true
     url_docs: "https://huggingface.co/lllyasviel/sd-controlnet-mlsd"
 
@@ -38,6 +43,7 @@ models:
     type: "normalmap"
     description: "ControlNet is a neural network structure to control diffusion models by adding extra conditions. This checkpoint corresponds to the ControlNet conditioned on Normal Map Estimation."
     source: "lllyasviel/sd-controlnet-normal"
+    kind: "controlnet"
     is_active: true
     url_docs: "https://huggingface.co/lllyasviel/sd-controlnet-normal"
 
@@ -45,6 +51,7 @@ models:
     type: "poses"
     description: "ControlNet is a neural network structure to control diffusion models by adding extra conditions. This checkpoint corresponds to the ControlNet conditioned on Human Pose Estimation."
     source: "lllyasviel/sd-controlnet-openpose"
+    kind: "controlnet"
     is_active: true
     url_docs: "https://huggingface.co/lllyasviel/sd-controlnet-openpose"
 
@@ -52,6 +59,7 @@ models:
     type: "scribble"
     description: "ControlNet is a neural network structure to control diffusion models by adding extra conditions. This checkpoint corresponds to the ControlNet conditioned on Scribble images."
     source: "lllyasviel/sd-controlnet-scribble"
+    kind: "controlnet"
     is_active: true
     url_docs: "https://huggingface.co/lllyasviel/sd-controlnet-scribble"
 

--- a/morpheus-server/scripts/models/magicprompt-models-info.yaml
+++ b/morpheus-server/scripts/models/magicprompt-models-info.yaml
@@ -2,5 +2,6 @@ models:
   - name: "Gustavosta/MagicPrompt-Stable-Diffusion"
     description: "This is a model from the MagicPrompt series of models, which are GPT-2 models intended to generate prompt texts for imaging AIs, in this case: Stable Diffusion."
     source: "Gustavosta/MagicPrompt-Stable-Diffusion"
+    kind: "prompt"
     is_active: true
     url_docs: "https://huggingface.co/Gustavosta/MagicPrompt-Stable-Diffusion"

--- a/morpheus-server/scripts/models/models-info.yaml
+++ b/morpheus-server/scripts/models/models-info.yaml
@@ -3,6 +3,7 @@ models:
   - name: "Stable Diffusion XL"
     description: "SDXL 1.0: A Leap Forward in AI Image Generation"
     source: "stabilityai/stable-diffusion-xl-base-1.0"
+    kind: "diffusion"
     is_active: true
     url_docs: "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0"
     text2img: true
@@ -15,6 +16,7 @@ models:
   - name: "Stable Diffusion v2"
     description: "This is a model that can be used to generate and modify images based on text prompts. It is a Latent Diffusion Model that uses a fixed, pretrained text encoder (OpenCLIP-ViT/H)."
     source: "stabilityai/stable-diffusion-2"
+    kind: "diffusion"
     is_active: true
     url_docs: "https://huggingface.co/stabilityai/stable-diffusion-2"
     text2img: true
@@ -27,6 +29,7 @@ models:
   - name: "Openjourney"
     description: "Openjourney is an open source Stable Diffusion fine tuned model on Midjourney images, by PromptHero."
     source: "prompthero/openjourney"
+    kind: "diffusion"
     is_active: true
     url_docs: "https://huggingface.co/prompthero/openjourney"
     text2img: true
@@ -39,6 +42,7 @@ models:
   - name: "Stable Diffusion v1.5"
     description: "Stable Diffusion is a latent text-to-image diffusion model capable of generating photo-realistic images given any text input. he Stable-Diffusion-v1-5 checkpoint was initialized with the weights of the Stable-Diffusion-v1-2 checkpoint and subsequently fine-tuned on 595k steps at resolution 512x512 on 'laion-aesthetics v2 5+' and 10% dropping of the text-conditioning to improve classifier-free guidance sampling."
     source: "runwayml/stable-diffusion-v1-5"
+    kind: "diffusion"
     is_active: true
     url_docs: "https://huggingface.co/runwayml/stable-diffusion-v1-5"
     text2img: true
@@ -51,6 +55,7 @@ models:
   - name: "Instruct Pix2Pix"
     description: "Modify an existing image with a text prompt."
     source: "timbrooks/instruct-pix2pix"
+    kind: "diffusion"
     is_active: true
     url_docs: "https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/pix2pix"
     text2img: false
@@ -63,6 +68,7 @@ models:
   - name: "SD Inpainting"
     description: "Modify an existing image with a text prompt and an image mask."
     source: "runwayml/stable-diffusion-inpainting"
+    kind: "diffusion"
     is_active: true
     url_docs: "https://huggingface.co/runwayml/stable-diffusion-inpainting"
     text2img: false
@@ -75,6 +81,7 @@ models:
   - name: "SD x4 Upscaler"
     description: "Stable Diffusion x4 Upscaler can be used to enhance the resolution of input images by a factor of 4."
     source: "stabilityai/stable-diffusion-x4-upscaler"
+    kind: "diffusion"
     is_active: true
     url_docs: "https://huggingface.co/stabilityai/stable-diffusion-x4-upscaler"
     text2img: false

--- a/morpheus-server/scripts/models/s3.py
+++ b/morpheus-server/scripts/models/s3.py
@@ -1,40 +1,27 @@
-from glob import glob
-from pathlib import Path
-
 import typer
 
 from config import Target, config_file, download_model
 from utils import load_config_from_file
 
-from morpheus_data.repository.files.s3_models_repository import S3ModelFileRepository  # noqa: E402
+from morpheus_data.registry.s3_model_registry import S3ModelRegistry  # noqa: E402
+
 
 app = typer.Typer(help="subcommand to manage models in S3:  register/list/delete")
 
+model_registry = S3ModelRegistry()
+
 
 def register_model_in_s3(output_path: str) -> None:
-    model_repository = S3ModelFileRepository()
-    is_in_s3 = model_repository.files_exists(output_path)
-
-    if is_in_s3:
-        print("Model already exists in s3")
-        return
-
-    list_of_content = glob(f"./tmp/{output_path}/**/*", recursive=True)
-    list_of_files = [file for file in list_of_content if Path(file).is_file()]
-    model_repository.upload_files(list_of_files)
-    print("Model uploaded to the S3 bucket")
+    model_registry.register_model_in_storage(output_path=output_path)
 
 
 def delete_model_from_s3(name):
-    model_repository = S3ModelFileRepository()
-    model_repository.delete_file(name.replace(" ", "_"))
-    print("Model deleted from S3 bucket")
+    model_registry.delete_model_from_storage(name=name)
 
 
 @app.command("list")
-def list(folder: str = typer.Argument("")) -> None:
-    model_repository = S3ModelFileRepository()
-    model_repository.list_content(folder=folder)
+def list_s3_content(folder: str = typer.Argument("")) -> None:
+    model_registry.list_storage(folder=folder)
 
 
 @app.command("register")


### PR DESCRIPTION
Move all model-script operations related to S3 and download model in local, to morpheus-data
This is for being able to use them in morpheus-server in models-api when a new model will be registered using morpheus-admin

 - create interfaces for register and model manager
 - implement script functions to upload model in register and model manager
 - create new field in ml_model table
 - creare new field in MLModelCreate schema
 - update dependencies in morpheus-data
 - update yaml files in model-script with new field
 - update model-script to import and use functions from morpheus-data
 - add new command in model-scrip[t cli to list downloaded local models

### Some screenshots using model-script

<img width="1162" alt="CleanShot 2023-09-18 at 14 48 35@2x" src="https://github.com/Monadical-SAS/Morpheus/assets/1589267/d1500433-4187-45ea-aafd-27bb56e297a5">

<img width="1033" alt="CleanShot 2023-09-18 at 14 49 12@2x" src="https://github.com/Monadical-SAS/Morpheus/assets/1589267/4d7ba77b-b48f-4e27-9d26-c469c31fa90b">

<img width="1073" alt="CleanShot 2023-09-18 at 14 49 36@2x" src="https://github.com/Monadical-SAS/Morpheus/assets/1589267/f98946fa-ee98-4f7f-9e2f-27b7b8efcd25">

![CleanShot 2023-09-18 at 14 50 06](https://github.com/Monadical-SAS/Morpheus/assets/1589267/9df57a6e-c795-4740-a92b-dc08c1d1db8d)



