### PR TITLE
feat(admin/back): add s3 and download operations in models services

### DIFF
--- a/morpheus-data/morpheus_data/repository/model_category_repository.py
+++ b/morpheus-data/morpheus_data/repository/model_category_repository.py
@@ -4,6 +4,7 @@ from uuid import UUID
 from sqlalchemy.orm import Session
 
 from morpheus_data.models.models import ModelCategory
+from morpheus_data.models.schemas import MLModelCreate
 
 
 class ModelCategoryRepository:
@@ -29,6 +30,10 @@ class ModelCategoryRepository:
     @classmethod
     def get_category_by_name(cls, *, db: Session, name: str) -> ModelCategory:
         return db.query(ModelCategory).filter(ModelCategory.name == name).first()
+
+    @classmethod
+    def get_categories_by_model(cls, *, db: Session, model: MLModelCreate) -> List[ModelCategory]:
+        return db.query(ModelCategory).filter(ModelCategory.models.id == model.id).all()
 
     @classmethod
     def update_category(cls, *, db: Session, category: ModelCategory) -> ModelCategory:

--- a/morpheus-data/morpheus_data/repository/model_repository.py
+++ b/morpheus-data/morpheus_data/repository/model_repository.py
@@ -13,6 +13,7 @@ class ModelRepository:
         db_model = MLModel(
             name=model.name,
             source=model.source,
+            kind=model.kind,
             description=model.description,
             url_docs=model.url_docs,
             extra_params=model.extra_params,
@@ -44,10 +45,18 @@ class ModelRepository:
 
     @classmethod
     def update_model(cls, *, db: Session, model: MLModelCreate) -> MLModel:
-        query = db.query(MLModel).filter(MLModel.source == model.source)
-        query.update(model.dict(), synchronize_session="fetch")
+        db_model: MLModel = db.query(MLModel).filter(MLModel.source == model.source).first()
+
+        db_model.name = model.name
+        db_model.description = model.description
+        db_model.source = model.source
+        db_model.kind = model.kind
+        db_model.url_docs = model.url_docs
+        db_model.categories = model.categories
+        db_model.extra_params = model.extra_params
+        db_model.is_active = model.is_active
         db.commit()
-        return query.first()
+        return db_model
 
     @classmethod
     def delete_model_by_source(cls, *, db: Session, model_source: str) -> MLModel:

--- a/morpheus-server/app/services/models_services.py
+++ b/morpheus-server/app/services/models_services.py
@@ -3,26 +3,45 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
+from app.config import EnvironmentEnum, get_settings
 from morpheus_data.models.schemas import MLModel, MLModelCreate
+from morpheus_data.registry.model_manager import ModelManagerHuggingFace
+from morpheus_data.registry.s3_model_registry import S3ModelRegistry
 from morpheus_data.repository.model_category_repository import ModelCategoryRepository
 from morpheus_data.repository.model_repository import ModelRepository
+
+settings = get_settings()
 
 
 class ModelService:
     def __init__(self):
         self.category_repository = ModelCategoryRepository()
         self.model_repository = ModelRepository()
+        self.s3_model_registry = S3ModelRegistry()
+        self.model_manager = ModelManagerHuggingFace()
 
     async def create_model(self, *, db: Session, model: MLModelCreate) -> MLModel:
         if not len(model.categories) > 0:
             raise ValueError("Model must have at least one category")
+
+        # 1. Validating categories in DB
         db_categories = [
-            self.category_repository.get_category_by_name(db=db, name=category.name)
-            for category in model.categories
+            self.category_repository.get_category_by_name(db=db, name=category.name) for category in model.categories
         ]
         if not any(db_categories):
             raise ValueError("No category found")
 
+        # 2. Download model from source
+        output_path = self.model_manager.download_model(kind=model.kind, params=model)
+
+        # 3. Register model in S3
+        self.s3_model_registry.register_model_in_storage(output_path=output_path)
+
+        # 4. Delete model from local
+        if settings.environment == EnvironmentEnum.prod:
+            self.model_manager.remove_model(name=output_path)
+
+        # 5. Create model in DB and return
         return self.model_repository.create_model(db=db, model=model, categories=db_categories)
 
     async def get_models(self, *, db: Session) -> List[MLModel]:
@@ -39,7 +58,25 @@ class ModelService:
         return self.model_repository.get_model_by_source(db=db, model_source=model_source)
 
     async def update_model(self, *, db: Session, model: MLModelCreate) -> MLModel:
+        model_db = self.model_repository.get_model_by_source(db=db, model_source=model.source)
+        model_categories = self.category_repository.get_categories_by_model(db=db, model=model)
+        if model.categories != model_categories:
+            model.categories = [
+                self.category_repository.get_category_by_name(db=db, name=category.name)
+                for category in model.categories
+            ]
+        if model_db.is_active != model.is_active and settings.environment == EnvironmentEnum.prod:
+            if model.is_active:
+                self.s3_model_registry.register_model_in_storage(output_path=model.source)
+            else:
+                self.s3_model_registry.delete_model_from_storage(name=model.source)
+
         return self.model_repository.update_model(db=db, model=model)
 
     async def delete_model_by_source(self, *, db: Session, model_source: str) -> MLModel:
+        # 1. Delete model from disk
+        self.model_manager.remove_model(name=model_source)
+        # 2. Delete model from S3
+        self.s3_model_registry.delete_model_from_storage(name=model_source)
+        # 3. Delete model from DB and return
         return self.model_repository.delete_model_by_source(db=db, model_source=model_source)


### PR DESCRIPTION
- add download-model instruction in create model service
- add register-model-in-s3 instruction in create model service
- add model categories query in update model service
- remove models from s3 when model is deactivated in updade model service
- add remove-model from disk in delete model service
- add delete-model-from-s3 in delete model service
- update field by field in update model repository
- add function to get categories by model in model category repository

## Some tests using model-script cli

### uploading a new model that already is downloaded and exists in S3
 
* model in yaml file:
   ```yaml
   models:
      - name: "Stable Diffusion XL"
        description: "SDXL 1.0: A Leap Forward in AI Image Generation"
        source: "stabilityai/stable-diffusion-xl-base-1.0"
        kind: "diffusion"
        is_active: true
        url_docs: "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0"
        categories:
          - name: "text2img"
          - name: "img2img"
          - name: "inpainting"
   ```
**Output from cli:**
<img width="1121" alt="CleanShot 2023-09-18 at 21 53 03@2x" src="https://github.com/Monadical-SAS/Morpheus/assets/1589267/15972d70-cf03-4f1d-ba60-19c2bd3d4366">

**Logs in api:**
<img width="1440" alt="CleanShot 2023-09-18 at 21 53 49@2x" src="https://github.com/Monadical-SAS/Morpheus/assets/1589267/fd5e012d-3611-4abf-8595-3b7282bef161">

**Trying to register the same model again with cli**
<img width="988" alt="CleanShot 2023-09-18 at 22 01 52@2x" src="https://github.com/Monadical-SAS/Morpheus/assets/1589267/fd2e0f63-cb49-4de5-9798-1d7dcd857352">

